### PR TITLE
Replace euclid with nalgebra package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra-glm"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68879ff227a94627e63bbd518b4f82b8f0cc56bb01a498251507de6d1c412d6"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "simba",
+]
+
+[[package]]
 name = "nalgebra-macros"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,7 +978,8 @@ dependencies = [
 name = "points_on_curve"
 version = "0.5.0"
 dependencies = [
- "euclid",
+ "nalgebra",
+ "nalgebra-glm",
  "num-traits",
  "piet",
  "piet-common",
@@ -1096,6 +1109,7 @@ version = "0.1.0"
 dependencies = [
  "derive_builder",
  "nalgebra",
+ "nalgebra-glm",
  "num-traits",
  "palette",
  "piet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "bytemuck"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+
+[[package]]
 name = "cairo-rs"
 version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +603,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +626,63 @@ checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
  "simd-adler32",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -712,6 +785,12 @@ dependencies = [
  "pango-sys",
  "system-deps",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "phf"
@@ -992,6 +1071,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rough_piet"
 version = "0.6.0"
 dependencies = [
@@ -1010,7 +1095,7 @@ name = "roughfeel"
 version = "0.1.0"
 dependencies = [
  "derive_builder",
- "euclid",
+ "nalgebra",
  "num-traits",
  "palette",
  "piet",
@@ -1046,6 +1131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1166,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -1259,6 +1366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unic-bidi"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1526,16 @@ checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/points_on_curve/Cargo.toml
+++ b/points_on_curve/Cargo.toml
@@ -14,7 +14,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-euclid = "0.22"
+# euclid = "0.22"
+nalgebra = "0.32.3"
+nalgebra-glm = "0.18.0"
 num-traits = "0.2"
 
 [dev-dependencies]

--- a/points_on_curve/Cargo.toml
+++ b/points_on_curve/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# euclid = "0.22"
 nalgebra = "0.32.3"
 nalgebra-glm = "0.18.0"
 num-traits = "0.2"

--- a/points_on_curve/src/lib.rs
+++ b/points_on_curve/src/lib.rs
@@ -26,10 +26,10 @@
 //! use points_on_curve::points_on_bezier_curves;
 //!
 //! let input = vec![
-//!     point2(70.0, 240.0),
-//!     point2(145.0, 60.0),
-//!     point2(275.0, 90.0),
-//!     point2(300.0, 230.0),
+//!     Point2::new(70.0, 240.0),
+//!     Point2::new(145.0, 60.0),
+//!     Point2::new(275.0, 90.0),
+//!     Point2::new(300.0, 230.0),
 //! ];
 //! let result_015 = points_on_bezier_curves(&input, 0.2, Some(0.15));
 //! ```
@@ -52,10 +52,34 @@ use std::cmp::{max_by, min_by};
 use std::fmt::Display;
 use std::ops::MulAssign;
 
-pub use euclid;
-use euclid::default::Point2D;
-use euclid::point2;
+use nalgebra::{Point2, Scalar, distance_squared, distance};
+use nalgebra_glm::RealNumber;
+// pub use euclid;
+// use euclid::default::Point2D;
+// use euclid::point2;
 use num_traits::Float;
+
+fn distance_between_two_points<F, P>(p: P, v: P) -> F
+where
+    F: RealNumber + Display,
+    P: Borrow<Point2<F>>,
+{
+    let v_ = v.borrow();
+    let p_ = p.borrow();
+    ((p_.x - v_.x).powi(2) * (p_.y - v_.y).powi(2)).sqrt()
+}
+
+fn lerp_two_points<F, P>(p: P, v: P, w: F) -> Point2<F>
+where
+    F: RealNumber + Display,
+    P: Borrow<Point2<F>>,
+{
+    let v_ = v.borrow();
+    let p_ = p.borrow();
+    Point2::new(
+        p_.x + (v_.x - p_.x) * w,
+        p_.y + (v_.y - p_.y) * w)
+}
 
 /// computes distance squared from a point p to the line segment vw
 ///
@@ -64,20 +88,20 @@ use num_traits::Float;
 /// use euclid::point2;
 /// use points_on_curve::distance_to_segment_squared;
 /// let expected = 1.0;
-/// let result = distance_to_segment_squared(point2(0.0, 1.0), point2(-1.0, 0.0), point2(1.0, 0.0));
+/// let result = distance_to_segment_squared(Point2::new(0.0, 1.0), Point2::new(-1.0, 0.0), Point2::new(1.0, 0.0));
 /// assert_eq!(expected, result);
 /// ```
 pub fn distance_to_segment_squared<F, P>(p: P, v: P, w: P) -> F
 where
-    F: Float + PartialOrd + Display,
-    P: Borrow<Point2D<F>>,
+    F: RealNumber + Display,
+    P: Borrow<Point2<F>>,
 {
     let v_ = v.borrow();
     let w_ = w.borrow();
     let p_ = p.borrow();
-    let l2 = v_.distance_to(*w_).powi(2);
+    let l2 = distance_between_two_points(v_, w_).powi(2);
     if l2 == F::zero() {
-        p_.distance_to(*v_).powi(2)
+        distance_between_two_points(p_, v_).powi(2)
     } else {
         let mut t = ((p_.x - v_.x) * (w_.x - v_.x) + (p_.y - v_.y) * (w_.y - v_.y)) / l2;
         t = max_by(
@@ -91,22 +115,23 @@ where
                     .unwrap_or_else(|| panic!("can not compare {} and {}", a, b))
             },
         );
-        p_.distance_to(v_.lerp(*w_, t)).powi(2)
+        let lerp_result = lerp_two_points(v_, w_, t);
+        distance_between_two_points(p_, &lerp_result).powi(2)
     }
 }
 
 /// Adapted from https://seant23.wordpress.com/2010/11/12/offset-bezier-curves/
-pub fn flatness<F>(points: &[Point2D<F>], offset: usize) -> F
+pub fn flatness<F>(points: &[Point2<F>], offset: usize) -> F
 where
-    F: Float + MulAssign,
+    F: RealNumber,
 {
     let p1 = points[offset];
     let p2 = points[offset + 1];
     let p3 = points[offset + 2];
     let p4 = points[offset + 3];
 
-    let const_3 = F::from(3).unwrap();
-    let const_2 = F::from(2).unwrap();
+    let const_3 = F::from_i32(3).unwrap();
+    let const_2 = F::from_i32(2).unwrap();
 
     let mut ux = const_3 * p2.x - const_2 * p1.x - p4.x;
     ux *= ux;
@@ -126,14 +151,14 @@ where
 }
 
 fn simplify_points<F>(
-    points: &[Point2D<F>],
+    points: &[Point2<F>],
     start: usize,
     end: usize,
     epsilon: F,
-    new_points: &mut Vec<Point2D<F>>,
-) -> Vec<Point2D<F>>
+    new_points: &mut Vec<Point2<F>>,
+) -> Vec<Point2<F>>
 where
-    F: Float + Display,
+    F: RealNumber + Display,
 {
     let s = points[start];
     let e = points[end - 1];
@@ -162,26 +187,26 @@ where
 
 /// Simplifies given points on curve by reducing number of points using Ramer–Douglas–Peucker algorithm
 /// https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
-pub fn simplify<F>(points: &[Point2D<F>], distance: F) -> Vec<Point2D<F>>
+pub fn simplify<F>(points: &[Point2<F>], distance: F) -> Vec<Point2<F>>
 where
-    F: Float + Display,
+    F: RealNumber + Display,
 {
     simplify_points(points, 0, points.len(), distance, &mut vec![])
 }
 
 fn get_points_on_bezier_curve_with_splitting<F>(
-    points: &[Point2D<F>],
+    points: &[Point2<F>],
     offset: usize,
     tolerance: F,
-    new_points: &mut Vec<Point2D<F>>,
-) -> Vec<Point2D<F>>
+    new_points: &mut Vec<Point2<F>>,
+) -> Vec<Point2<F>>
 where
-    F: Float + MulAssign,
+    F: RealNumber + Display,
 {
     if flatness(points, offset) < tolerance {
         let p0 = points[offset];
         if !new_points.is_empty() {
-            let d = new_points.last().unwrap().distance_to(p0);
+            let d = distance_between_two_points(new_points.last().unwrap(), &p0);
             if d > F::one() {
                 new_points.push(p0);
             }
@@ -190,20 +215,20 @@ where
         }
         new_points.push(points[offset + 3]);
     } else {
-        let t = F::from(0.5).unwrap();
+        let t = F::from_f32(0.5).unwrap();
         let p1 = points[offset];
         let p2 = points[offset + 1];
         let p3 = points[offset + 2];
         let p4 = points[offset + 3];
 
-        let q1 = p1.lerp(p2, t);
-        let q2 = p2.lerp(p3, t);
-        let q3 = p3.lerp(p4, t);
+        let q1 = lerp_two_points(&p1, &p2, t);
+        let q2 = lerp_two_points(&p2, &p3, t);
+        let q3 = lerp_two_points(&p3, &p4, t);
 
-        let r1 = q1.lerp(q2, t);
-        let r2 = q2.lerp(q3, t);
+        let r1 = lerp_two_points(&q1, &q2, t);
+        let r2 = lerp_two_points(&q2, &q3, t);
 
-        let red = r1.lerp(r2, t);
+        let red = lerp_two_points(&r1, &r2, t);
 
         get_points_on_bezier_curve_with_splitting(&[p1, q1, r1, red], 0, tolerance, new_points);
         get_points_on_bezier_curve_with_splitting(&[red, r2, q3, p4], 0, tolerance, new_points);
@@ -215,12 +240,12 @@ where
 /// Samples points on a Bezier Curve. If distance parameter is given does simplification on sampled points
 /// and reduces number of points that represents given Bezier Curve.
 pub fn points_on_bezier_curves<F>(
-    points: &[Point2D<F>],
+    points: &[Point2<F>],
     tolerance: F,
     distance: Option<F>,
-) -> Vec<Point2D<F>>
+) -> Vec<Point2<F>>
 where
-    F: Float + MulAssign + Display,
+    F: RealNumber + Display,
 {
     let mut new_points = vec![];
     let num_segments = points.len() / 3;
@@ -238,9 +263,9 @@ where
 }
 
 /// Generates Bezier Curve parameters passing through given points
-pub fn curve_to_bezier<F>(points_in: &[Point2D<F>], curve_tightness: F) -> Option<Vec<Point2D<F>>>
+pub fn curve_to_bezier<F>(points_in: &[Point2<F>], curve_tightness: F) -> Option<Vec<Point2<F>>>
 where
-    F: Float,
+    F: RealNumber,
 {
     if points_in.len() < 3 {
         None
@@ -266,17 +291,17 @@ where
             for i in 1..points.len() - 2 {
                 let cached_point = points[i];
                 //let b_0  = cached_point.clone();
-                let b_1 = point2(
+                let b_1 = Point2::new(
                     cached_point.x
-                        + (s * points[i + 1].x - s * points[i - 1].x) / F::from(6).unwrap(),
+                        + (s * points[i + 1].x - s * points[i - 1].x) / F::from_i32(6).unwrap(),
                     cached_point.y
-                        + (s * points[i + 1].y - s * points[i - 1].y) / F::from(6).unwrap(),
+                        + (s * points[i + 1].y - s * points[i - 1].y) / F::from_i32(6).unwrap(),
                 );
-                let b_2 = point2(
-                    points[i + 1].x + (s * points[i].x - s * points[i + 2].x) / F::from(6).unwrap(),
-                    points[i + 1].y + (s * points[i].y - s * points[i + 2].y) / F::from(6).unwrap(),
+                let b_2 = Point2::new(
+                    points[i + 1].x + (s * points[i].x - s * points[i + 2].x) / F::from_i32(6).unwrap(),
+                    points[i + 1].y + (s * points[i].y - s * points[i + 2].y) / F::from_i32(6).unwrap(),
                 );
-                let b_3 = point2(points[i + 1].x, points[i + 1].y);
+                let b_3 = Point2::new(points[i + 1].x, points[i + 1].y);
                 out.push(b_1);
                 out.push(b_2);
                 out.push(b_3);
@@ -288,15 +313,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use euclid::point2;
+    use nalgebra::Point2;
 
     #[test]
     fn distance_to_segment_squared() {
         let expected = 1.0;
         let result = super::distance_to_segment_squared(
-            point2(0.0, 1.0),
-            point2(-1.0, 0.0),
-            point2(1.0, 0.0),
+            Point2::new(0.0, 1.0),
+            Point2::new(-1.0, 0.0),
+            Point2::new(1.0, 0.0),
         );
         assert_eq!(expected, result);
     }
@@ -306,10 +331,10 @@ mod tests {
         let expected = 9.0;
         let result = super::flatness(
             &[
-                point2(0.0, 1.0),
-                point2(1.0, 3.0),
-                point2(2.0, 3.0),
-                point2(3.0, 4.0),
+                Point2::new(0.0, 1.0),
+                Point2::new(1.0, 3.0),
+                Point2::new(2.0, 3.0),
+                Point2::new(3.0, 4.0),
             ],
             0,
         );
@@ -319,78 +344,78 @@ mod tests {
     #[test]
     fn points_on_bezier_curves() {
         let expected = vec![
-            point2(70.0, 240.0),
-            point2(73.5552978515625, 231.71592712402344),
-            point2(77.1875, 223.7371826171875),
-            point2(80.8929443359375, 216.0614776611328),
-            point2(84.66796875, 208.6865234375),
-            point2(88.5089111328125, 201.6100311279297),
-            point2(92.412109375, 194.8297119140625),
-            point2(96.3739013671875, 188.34327697753906),
-            point2(100.390625, 182.1484375),
-            point2(104.4586181640625, 176.24290466308594),
-            point2(108.57421875, 170.6243896484375),
-            point2(112.7337646484375, 165.2906036376953),
-            point2(116.93359375, 160.2392578125),
-            point2(121.1700439453125, 155.4680633544922),
-            point2(125.439453125, 150.9747314453125),
-            point2(129.7381591796875, 146.75697326660156),
-            point2(134.0625, 142.8125),
-            point2(138.4088134765625, 139.13902282714844),
-            point2(142.7734375, 135.7342529296875),
-            point2(147.1527099609375, 132.5959014892578),
-            point2(151.54296875, 129.7216796875),
-            point2(155.9405517578125, 127.10929870605469),
-            point2(160.341796875, 124.7564697265625),
-            point2(164.7430419921875, 122.66090393066406),
-            point2(169.140625, 120.8203125),
-            point2(173.5308837890625, 119.23240661621094),
-            point2(177.91015625, 117.8948974609375),
-            point2(182.2747802734375, 116.80549621582031),
-            point2(186.62109375, 115.9619140625),
-            point2(190.9454345703125, 115.36186218261719),
-            point2(195.244140625, 115.0030517578125),
-            point2(199.5135498046875, 114.88319396972656),
-            point2(203.75, 115.0),
-            point2(207.9498291015625, 115.35118103027344),
-            point2(212.109375, 115.9344482421875),
-            point2(216.2249755859375, 116.74751281738281),
-            point2(220.29296875, 117.7880859375),
-            point2(224.3096923828125, 119.05387878417969),
-            point2(228.271484375, 120.5426025390625),
-            point2(232.1746826171875, 122.25196838378906),
-            point2(236.015625, 124.1796875),
-            point2(239.7906494140625, 126.32347106933594),
-            point2(243.49609375, 128.6810302734375),
-            point2(247.1282958984375, 131.2500762939453),
-            point2(250.68359375, 134.0283203125),
-            point2(254.1583251953125, 137.0134735107422),
-            point2(257.548828125, 140.2032470703125),
-            point2(260.8514404296875, 143.59535217285156),
-            point2(264.0625, 147.1875),
-            point2(267.1783447265625, 150.97740173339844),
-            point2(270.1953125, 154.9627685546875),
-            point2(273.1097412109375, 159.1413116455078),
-            point2(275.91796875, 163.5107421875),
-            point2(278.6163330078125, 168.0687713623047),
-            point2(281.201171875, 172.8131103515625),
-            point2(283.6688232421875, 177.74147033691406),
-            point2(286.015625, 182.8515625),
-            point2(288.2379150390625, 188.14109802246094),
-            point2(290.33203125, 193.6077880859375),
-            point2(292.2943115234375, 199.2493438720703),
-            point2(294.12109375, 205.0634765625),
-            point2(295.8087158203125, 211.0478973388672),
-            point2(297.353515625, 217.2003173828125),
-            point2(298.7518310546875, 223.51844787597656),
-            point2(300.0, 230.0),
+            Point2::new(70.0, 240.0),
+            Point2::new(73.5552978515625, 231.71592712402344),
+            Point2::new(77.1875, 223.7371826171875),
+            Point2::new(80.8929443359375, 216.0614776611328),
+            Point2::new(84.66796875, 208.6865234375),
+            Point2::new(88.5089111328125, 201.6100311279297),
+            Point2::new(92.412109375, 194.8297119140625),
+            Point2::new(96.3739013671875, 188.34327697753906),
+            Point2::new(100.390625, 182.1484375),
+            Point2::new(104.4586181640625, 176.24290466308594),
+            Point2::new(108.57421875, 170.6243896484375),
+            Point2::new(112.7337646484375, 165.2906036376953),
+            Point2::new(116.93359375, 160.2392578125),
+            Point2::new(121.1700439453125, 155.4680633544922),
+            Point2::new(125.439453125, 150.9747314453125),
+            Point2::new(129.7381591796875, 146.75697326660156),
+            Point2::new(134.0625, 142.8125),
+            Point2::new(138.4088134765625, 139.13902282714844),
+            Point2::new(142.7734375, 135.7342529296875),
+            Point2::new(147.1527099609375, 132.5959014892578),
+            Point2::new(151.54296875, 129.7216796875),
+            Point2::new(155.9405517578125, 127.10929870605469),
+            Point2::new(160.341796875, 124.7564697265625),
+            Point2::new(164.7430419921875, 122.66090393066406),
+            Point2::new(169.140625, 120.8203125),
+            Point2::new(173.5308837890625, 119.23240661621094),
+            Point2::new(177.91015625, 117.8948974609375),
+            Point2::new(182.2747802734375, 116.80549621582031),
+            Point2::new(186.62109375, 115.9619140625),
+            Point2::new(190.9454345703125, 115.36186218261719),
+            Point2::new(195.244140625, 115.0030517578125),
+            Point2::new(199.5135498046875, 114.88319396972656),
+            Point2::new(203.75, 115.0),
+            Point2::new(207.9498291015625, 115.35118103027344),
+            Point2::new(212.109375, 115.9344482421875),
+            Point2::new(216.2249755859375, 116.74751281738281),
+            Point2::new(220.29296875, 117.7880859375),
+            Point2::new(224.3096923828125, 119.05387878417969),
+            Point2::new(228.271484375, 120.5426025390625),
+            Point2::new(232.1746826171875, 122.25196838378906),
+            Point2::new(236.015625, 124.1796875),
+            Point2::new(239.7906494140625, 126.32347106933594),
+            Point2::new(243.49609375, 128.6810302734375),
+            Point2::new(247.1282958984375, 131.2500762939453),
+            Point2::new(250.68359375, 134.0283203125),
+            Point2::new(254.1583251953125, 137.0134735107422),
+            Point2::new(257.548828125, 140.2032470703125),
+            Point2::new(260.8514404296875, 143.59535217285156),
+            Point2::new(264.0625, 147.1875),
+            Point2::new(267.1783447265625, 150.97740173339844),
+            Point2::new(270.1953125, 154.9627685546875),
+            Point2::new(273.1097412109375, 159.1413116455078),
+            Point2::new(275.91796875, 163.5107421875),
+            Point2::new(278.6163330078125, 168.0687713623047),
+            Point2::new(281.201171875, 172.8131103515625),
+            Point2::new(283.6688232421875, 177.74147033691406),
+            Point2::new(286.015625, 182.8515625),
+            Point2::new(288.2379150390625, 188.14109802246094),
+            Point2::new(290.33203125, 193.6077880859375),
+            Point2::new(292.2943115234375, 199.2493438720703),
+            Point2::new(294.12109375, 205.0634765625),
+            Point2::new(295.8087158203125, 211.0478973388672),
+            Point2::new(297.353515625, 217.2003173828125),
+            Point2::new(298.7518310546875, 223.51844787597656),
+            Point2::new(300.0, 230.0),
         ];
 
         let input = vec![
-            point2(70.0, 240.0),
-            point2(145.0, 60.0),
-            point2(275.0, 90.0),
-            point2(300.0, 230.0),
+            Point2::new(70.0, 240.0),
+            Point2::new(145.0, 60.0),
+            Point2::new(275.0, 90.0),
+            Point2::new(300.0, 230.0),
         ];
         let result = super::points_on_bezier_curves(&input, 0.15, None);
         assert_eq!(result, expected);
@@ -399,45 +424,45 @@ mod tests {
     #[test]
     fn points_on_bezier_curves_with_tolerance() {
         let expected = vec![
-            point2(70.0, 240.0),
-            point2(77.1875, 223.7371826171875),
-            point2(84.66796875, 208.6865234375),
-            point2(92.412109375, 194.8297119140625),
-            point2(100.390625, 182.1484375),
-            point2(108.57421875, 170.6243896484375),
-            point2(116.93359375, 160.2392578125),
-            point2(125.439453125, 150.9747314453125),
-            point2(134.0625, 142.8125),
-            point2(142.7734375, 135.7342529296875),
-            point2(151.54296875, 129.7216796875),
-            point2(160.341796875, 124.7564697265625),
-            point2(169.140625, 120.8203125),
-            point2(177.91015625, 117.8948974609375),
-            point2(186.62109375, 115.9619140625),
-            point2(195.244140625, 115.0030517578125),
-            point2(203.75, 115.0),
-            point2(212.109375, 115.9344482421875),
-            point2(220.29296875, 117.7880859375),
-            point2(228.271484375, 120.5426025390625),
-            point2(236.015625, 124.1796875),
-            point2(243.49609375, 128.6810302734375),
-            point2(250.68359375, 134.0283203125),
-            point2(257.548828125, 140.2032470703125),
-            point2(264.0625, 147.1875),
-            point2(270.1953125, 154.9627685546875),
-            point2(275.91796875, 163.5107421875),
-            point2(281.201171875, 172.8131103515625),
-            point2(286.015625, 182.8515625),
-            point2(290.33203125, 193.6077880859375),
-            point2(294.12109375, 205.0634765625),
-            point2(297.353515625, 217.2003173828125),
-            point2(300.0, 230.0),
+            Point2::new(70.0, 240.0),
+            Point2::new(77.1875, 223.7371826171875),
+            Point2::new(84.66796875, 208.6865234375),
+            Point2::new(92.412109375, 194.8297119140625),
+            Point2::new(100.390625, 182.1484375),
+            Point2::new(108.57421875, 170.6243896484375),
+            Point2::new(116.93359375, 160.2392578125),
+            Point2::new(125.439453125, 150.9747314453125),
+            Point2::new(134.0625, 142.8125),
+            Point2::new(142.7734375, 135.7342529296875),
+            Point2::new(151.54296875, 129.7216796875),
+            Point2::new(160.341796875, 124.7564697265625),
+            Point2::new(169.140625, 120.8203125),
+            Point2::new(177.91015625, 117.8948974609375),
+            Point2::new(186.62109375, 115.9619140625),
+            Point2::new(195.244140625, 115.0030517578125),
+            Point2::new(203.75, 115.0),
+            Point2::new(212.109375, 115.9344482421875),
+            Point2::new(220.29296875, 117.7880859375),
+            Point2::new(228.271484375, 120.5426025390625),
+            Point2::new(236.015625, 124.1796875),
+            Point2::new(243.49609375, 128.6810302734375),
+            Point2::new(250.68359375, 134.0283203125),
+            Point2::new(257.548828125, 140.2032470703125),
+            Point2::new(264.0625, 147.1875),
+            Point2::new(270.1953125, 154.9627685546875),
+            Point2::new(275.91796875, 163.5107421875),
+            Point2::new(281.201171875, 172.8131103515625),
+            Point2::new(286.015625, 182.8515625),
+            Point2::new(290.33203125, 193.6077880859375),
+            Point2::new(294.12109375, 205.0634765625),
+            Point2::new(297.353515625, 217.2003173828125),
+            Point2::new(300.0, 230.0),
         ];
         let input = vec![
-            point2(70.0, 240.0),
-            point2(145.0, 60.0),
-            point2(275.0, 90.0),
-            point2(300.0, 230.0),
+            Point2::new(70.0, 240.0),
+            Point2::new(145.0, 60.0),
+            Point2::new(275.0, 90.0),
+            Point2::new(300.0, 230.0),
         ];
         let result = super::points_on_bezier_curves(&input, 0.7, None);
         assert_eq!(result, expected);
@@ -446,48 +471,48 @@ mod tests {
     #[test]
     fn points_on_bezier_curves_with_distance() {
         let expected = vec![
-            point2(70.0, 240.0),
-            point2(73.5552978515625, 231.71592712402344),
-            point2(80.8929443359375, 216.0614776611328),
-            point2(88.5089111328125, 201.6100311279297),
-            point2(96.3739013671875, 188.34327697753906),
-            point2(100.390625, 182.1484375),
-            point2(108.57421875, 170.6243896484375),
-            point2(116.93359375, 160.2392578125),
-            point2(125.439453125, 150.9747314453125),
-            point2(134.0625, 142.8125),
-            point2(142.7734375, 135.7342529296875),
-            point2(151.54296875, 129.7216796875),
-            point2(160.341796875, 124.7564697265625),
-            point2(169.140625, 120.8203125),
-            point2(177.91015625, 117.8948974609375),
-            point2(186.62109375, 115.9619140625),
-            point2(195.244140625, 115.0030517578125),
-            point2(203.75, 115.0),
-            point2(212.109375, 115.9344482421875),
-            point2(220.29296875, 117.7880859375),
-            point2(224.3096923828125, 119.05387878417969),
-            point2(232.1746826171875, 122.25196838378906),
-            point2(236.015625, 124.1796875),
-            point2(243.49609375, 128.6810302734375),
-            point2(250.68359375, 134.0283203125),
-            point2(257.548828125, 140.2032470703125),
-            point2(264.0625, 147.1875),
-            point2(270.1953125, 154.9627685546875),
-            point2(275.91796875, 163.5107421875),
-            point2(281.201171875, 172.8131103515625),
-            point2(286.015625, 182.8515625),
-            point2(290.33203125, 193.6077880859375),
-            point2(294.12109375, 205.0634765625),
-            point2(297.353515625, 217.2003173828125),
-            point2(300.0, 230.0),
+            Point2::new(70.0, 240.0),
+            Point2::new(73.5552978515625, 231.71592712402344),
+            Point2::new(80.8929443359375, 216.0614776611328),
+            Point2::new(88.5089111328125, 201.6100311279297),
+            Point2::new(96.3739013671875, 188.34327697753906),
+            Point2::new(100.390625, 182.1484375),
+            Point2::new(108.57421875, 170.6243896484375),
+            Point2::new(116.93359375, 160.2392578125),
+            Point2::new(125.439453125, 150.9747314453125),
+            Point2::new(134.0625, 142.8125),
+            Point2::new(142.7734375, 135.7342529296875),
+            Point2::new(151.54296875, 129.7216796875),
+            Point2::new(160.341796875, 124.7564697265625),
+            Point2::new(169.140625, 120.8203125),
+            Point2::new(177.91015625, 117.8948974609375),
+            Point2::new(186.62109375, 115.9619140625),
+            Point2::new(195.244140625, 115.0030517578125),
+            Point2::new(203.75, 115.0),
+            Point2::new(212.109375, 115.9344482421875),
+            Point2::new(220.29296875, 117.7880859375),
+            Point2::new(224.3096923828125, 119.05387878417969),
+            Point2::new(232.1746826171875, 122.25196838378906),
+            Point2::new(236.015625, 124.1796875),
+            Point2::new(243.49609375, 128.6810302734375),
+            Point2::new(250.68359375, 134.0283203125),
+            Point2::new(257.548828125, 140.2032470703125),
+            Point2::new(264.0625, 147.1875),
+            Point2::new(270.1953125, 154.9627685546875),
+            Point2::new(275.91796875, 163.5107421875),
+            Point2::new(281.201171875, 172.8131103515625),
+            Point2::new(286.015625, 182.8515625),
+            Point2::new(290.33203125, 193.6077880859375),
+            Point2::new(294.12109375, 205.0634765625),
+            Point2::new(297.353515625, 217.2003173828125),
+            Point2::new(300.0, 230.0),
         ];
 
         let input = vec![
-            point2(70.0, 240.0),
-            point2(145.0, 60.0),
-            point2(275.0, 90.0),
-            point2(300.0, 230.0),
+            Point2::new(70.0, 240.0),
+            Point2::new(145.0, 60.0),
+            Point2::new(275.0, 90.0),
+            Point2::new(300.0, 230.0),
         ];
         let result = super::points_on_bezier_curves(&input, 0.2, Some(0.15));
         assert_eq!(result, expected);
@@ -496,30 +521,30 @@ mod tests {
     #[test]
     fn curve_to_bezier() {
         let expected = vec![
-            point2(20.0, 240.0),
-            point2(32.5, 211.5),
-            point2(60.833333333333336, 94.0),
-            point2(95.0, 69.0),
-            point2(129.16666666666666, 44.0),
-            point2(199.16666666666666, 71.5),
-            point2(225.0, 90.0),
-            point2(250.83333333333334, 108.5),
-            point2(239.16666666666666, 158.33333333333334),
-            point2(250.0, 180.0),
-            point2(260.8333333333333, 201.66666666666666),
-            point2(268.3333333333333, 236.66666666666666),
-            point2(290.0, 220.0),
-            point2(311.6666666666667, 203.33333333333334),
-            point2(365.0, 103.33333333333333),
-            point2(380.0, 80.0),
+            Point2::new(20.0, 240.0),
+            Point2::new(32.5, 211.5),
+            Point2::new(60.833333333333336, 94.0),
+            Point2::new(95.0, 69.0),
+            Point2::new(129.16666666666666, 44.0),
+            Point2::new(199.16666666666666, 71.5),
+            Point2::new(225.0, 90.0),
+            Point2::new(250.83333333333334, 108.5),
+            Point2::new(239.16666666666666, 158.33333333333334),
+            Point2::new(250.0, 180.0),
+            Point2::new(260.8333333333333, 201.66666666666666),
+            Point2::new(268.3333333333333, 236.66666666666666),
+            Point2::new(290.0, 220.0),
+            Point2::new(311.6666666666667, 203.33333333333334),
+            Point2::new(365.0, 103.33333333333333),
+            Point2::new(380.0, 80.0),
         ];
         let input = vec![
-            point2(20.0, 240.0),
-            point2(95.0, 69.0),
-            point2(225.0, 90.0),
-            point2(250.0, 180.0),
-            point2(290.0, 220.0),
-            point2(380.0, 80.0),
+            Point2::new(20.0, 240.0),
+            Point2::new(95.0, 69.0),
+            Point2::new(225.0, 90.0),
+            Point2::new(250.0, 180.0),
+            Point2::new(290.0, 220.0),
+            Point2::new(380.0, 80.0),
         ];
         let result = super::curve_to_bezier(&input, 0.0).unwrap();
         assert_eq!(expected, result);

--- a/roughfeel/Cargo.toml
+++ b/roughfeel/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 derive_builder = "0.12.0"
 nalgebra = "0.32.3"
+nalgebra-glm = "0.18.0"
 num-traits = "0.2.17"
 palette = "0.7.3"
 piet = "0.6.2"

--- a/roughfeel/Cargo.toml
+++ b/roughfeel/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 derive_builder = "0.12.0"
-euclid = "0.22.9"
+nalgebra = "0.32.3"
 num-traits = "0.2.17"
 palette = "0.7.3"
 piet = "0.6.2"

--- a/roughfeel/examples/linear_path.rs
+++ b/roughfeel/examples/linear_path.rs
@@ -3,7 +3,7 @@
 
 // extern crate roughfeel;
 
-use euclid::{default, Point2D};
+use nalgebra::Point2;
 use palette::Srgba;
 use piet::{Color, RenderContext};
 use piet_common::kurbo::Rect;
@@ -44,10 +44,10 @@ fn main() {
     );
     //::default{}; //Generator::<f32, f32, KurboOpSet<f32>>::new(options);//::default();//::new(options);
     let points = [
-        Point2D::new(0.0, HEIGHT as f32 / 2.0),
-        Point2D::new(WIDTH as f32 / 2.0, HEIGHT as f32),
-        Point2D::new(WIDTH as f32, HEIGHT as f32 / 2.0),
-        Point2D::new(WIDTH as f32 / 2.0, 0.0),
+        Point2::new(0.0, HEIGHT as f32 / 2.0),
+        Point2::new(WIDTH as f32 / 2.0, HEIGHT as f32),
+        Point2::new(WIDTH as f32, HEIGHT as f32 / 2.0),
+        Point2::new(WIDTH as f32 / 2.0, 0.0),
     ];
     let linear_path = generator.linear_path(&points, true, &Some(options));
     let background_color = Color::from_hex_str("96C0B7").unwrap();

--- a/roughfeel/src/canvas.rs
+++ b/roughfeel/src/canvas.rs
@@ -1,6 +1,6 @@
 use derive_builder::Builder;
-use euclid::default::Point2D;
-use euclid::Trig;
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
 use num_traits::{Float, FromPrimitive};
 use palette::Srgba;
 use rand_chacha::{rand_core::block::BlockRngCore, ChaCha8Core};
@@ -9,7 +9,7 @@ use crate::graphics::drawable::DrawOptions;
 
 use crate::graphics::drawable_ops::{OpSet, OpSetType, OpType};
 
-pub struct Drawable2D<F: Float + Trig> {
+pub struct Drawable2D<F: RealNumber> {
     pub shape: String,
     pub options: DrawOptions,
     pub opsets: Vec<OpSet<F>>,

--- a/roughfeel/src/graphics/drawable.rs
+++ b/roughfeel/src/graphics/drawable.rs
@@ -1,7 +1,9 @@
 use derive_builder::Builder;
 use rand::{random, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use euclid::Trig;
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
+// use euclid::Trig;
 use num_traits::Float;
 use palette::Srgba;
 
@@ -151,12 +153,12 @@ impl DrawOptions {
 }
 
 pub trait OpSetTrait {
-    type F: Float + Trig;
+    type F: RealNumber;
 }
 
 pub trait Drawable<OpSetT: OpSetTrait>
 where
-    OpSetT::F: Float + Trig
+    OpSetT::F: RealNumber
 {
     // A drawable is a general concept for a graphic that can be drawn to the screen.
     fn draw(
@@ -168,14 +170,14 @@ where
 
 pub struct RoughlyDrawable<OpSetT: OpSetTrait> 
 where
-    OpSetT::F: Float + Trig, 
+    OpSetT::F: RealNumber, 
 {
     pub shape: String,
     pub options: DrawOptions,
     pub opsets: Vec<OpSetT>,
 }
 
-impl<AF: Float + Trig> Drawable<OpSet<AF>> for RoughlyDrawable<OpSet<AF>> {
+impl<AF: RealNumber> Drawable<OpSet<AF>> for RoughlyDrawable<OpSet<AF>> {
     fn draw(shape: String, options: DrawOptions, sets: Vec<OpSet<AF>>) -> RoughlyDrawable<OpSet<AF>> {
         Self {
             shape: shape.into(),

--- a/roughfeel/src/graphics/drawable_ops.rs
+++ b/roughfeel/src/graphics/drawable_ops.rs
@@ -1,5 +1,7 @@
-use euclid::default::Point2D;
-use euclid::Trig;
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
+// use euclid::default::Point2;
+// use euclid::Trig;
 use num_traits::Float;
 
 use super::drawable::OpSetTrait;
@@ -18,20 +20,21 @@ pub enum OpSetType {
     FillSketch,
 }
 
+/// A unified data structure that stores all drawing operations
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Op<F: Float + Trig> {
+pub struct Op<F: RealNumber> { //Paco: SIMD?
     pub op: OpType,
     pub data: Vec<F>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct OpSet<F: Float + Trig> {
+pub struct OpSet<F: RealNumber> {
     pub op_set_type: OpSetType,
     pub ops: Vec<Op<F>>,
-    pub size: Option<Point2D<F>>,
+    pub size: Option<Point2<F>>,
     pub path: Option<String>,
 }
 
-impl<F: Float + Trig> OpSetTrait for OpSet<F> {
+impl<F: RealNumber> OpSetTrait for OpSet<F> {
     type F = F;
 }

--- a/roughfeel/src/graphics/filler/dot_filler.rs
+++ b/roughfeel/src/graphics/filler/dot_filler.rs
@@ -1,8 +1,8 @@
 use std::borrow::BorrowMut;
 use std::marker::PhantomData;
 
-use euclid::default::Point2D;
-use euclid::Trig;
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
 use num_traits::{Float, FromPrimitive};
 
 use super::scan_line_hachure::polygon_hachure_lines;
@@ -20,8 +20,8 @@ pub struct DotFiller<F> {
 
 impl<F, P> PatternFiller<F, P> for DotFiller<F>
 where
-    F: Float + Trig + FromPrimitive,
-    P: BorrowMut<Vec<Vec<Point2D<F>>>>,
+    F: RealNumber,
+    P: BorrowMut<Vec<Vec<Point2<F>>>>,
 {
     fn fill_polygons(&self, mut polygon_list: P, o: &mut DrawOptions) -> OpSet<F> {
         o.set_hachure_angle(Some(0.0));
@@ -35,7 +35,7 @@ where
         }
     }
 }
-impl<F: Float + Trig + FromPrimitive> DotFiller<F> {
+impl<F: RealNumber> DotFiller<F> {
     pub fn new() -> Self {
         DotFiller {
             _phantom: PhantomData,
@@ -65,8 +65,10 @@ impl<F: Float + Trig + FromPrimitive> DotFiller<F> {
             let offset = length - (count * gap);
             let x = ((line.start_point.x + line.end_point.x) / _c::<F>(2.0)) - (gap / _c::<F>(4.0));
             let min_y = F::min(line.start_point.y, line.end_point.y);
-            for i in 0..count.to_u64().unwrap() {
-                let y = min_y + offset + (F::from(i).unwrap() * gap);
+
+            let count: f64 = nalgebra::try_convert(count).unwrap();
+            for i in 0..(count as u64) {
+                let y = min_y + offset + (F::from_u64(i).unwrap() * gap);
                 let cx = (x - ro) + _cc::<F>(o.random()) * _c::<F>(2.0) * ro;
                 let cy = (y - ro) + _cc::<F>(o.random()) * _c::<F>(2.0) * ro;
                 let ellipse_ops = ellipse(cx, cy, fweight, fweight, o);
@@ -78,7 +80,7 @@ impl<F: Float + Trig + FromPrimitive> DotFiller<F> {
     }
 }
 
-impl<F: Float + Trig + FromPrimitive> Default for DotFiller<F> {
+impl<F: RealNumber> Default for DotFiller<F> {
     fn default() -> Self {
         Self::new()
     }

--- a/roughfeel/src/graphics/filler/hatch_filler.rs
+++ b/roughfeel/src/graphics/filler/hatch_filler.rs
@@ -1,8 +1,8 @@
 use std::borrow::BorrowMut;
 use std::marker::PhantomData;
 
-use euclid::default::Point2D;
-use euclid::Trig;
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
 use num_traits::{Float, FromPrimitive};
 
 use super::scan_line_hachure::ScanlineHachureFiller;
@@ -18,8 +18,8 @@ pub struct HatchFiller<F> {
 
 impl<F, P> PatternFiller<F, P> for HatchFiller<F>
 where
-    F: Float + Trig + FromPrimitive,
-    P: BorrowMut<Vec<Vec<Point2D<F>>>>,
+    F: RealNumber,
+    P: BorrowMut<Vec<Vec<Point2<F>>>>,
 {
     fn fill_polygons(&self, mut polygon_list: P, o: &mut DrawOptions) -> OpSet<F> {
         let mut set1 = self
@@ -32,7 +32,7 @@ where
     }
 }
 
-impl<F: Float + Trig + FromPrimitive> HatchFiller<F> {
+impl<F: RealNumber> HatchFiller<F> {
     pub fn new() -> Self {
         HatchFiller {
             _phantom: PhantomData,
@@ -41,7 +41,7 @@ impl<F: Float + Trig + FromPrimitive> HatchFiller<F> {
     }
 }
 
-impl<F: Float + Trig + FromPrimitive> Default for HatchFiller<F> {
+impl<F: RealNumber> Default for HatchFiller<F> {
     fn default() -> Self {
         Self::new()
     }

--- a/roughfeel/src/graphics/filler/mod.rs
+++ b/roughfeel/src/graphics/filler/mod.rs
@@ -1,7 +1,7 @@
 use std::borrow::BorrowMut;
 
-use euclid::default::Point2D;
-use euclid::Trig;
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
 use num_traits::{Float, FromPrimitive};
 
 use self::dashed_filler::DashedFiller;
@@ -31,8 +31,8 @@ pub enum FillerType {
 
 pub fn get_filler<'a, F, P>(f: FillerType) -> Box<dyn PatternFiller<F, P> + 'a>
 where
-    F: Float + Trig + FromPrimitive + 'a,
-    P: BorrowMut<Vec<Vec<Point2D<F>>>>,
+    F: RealNumber + 'a,
+    P: BorrowMut<Vec<Vec<Point2<F>>>>,
 {
     match f {
         FillerType::ScanLineHachure => Box::new(ScanlineHachureFiller::new()),

--- a/roughfeel/src/graphics/filler/traits.rs
+++ b/roughfeel/src/graphics/filler/traits.rs
@@ -1,12 +1,12 @@
 use std::borrow::BorrowMut;
 
-use euclid::default::Point2D;
-use euclid::Trig;
+use nalgebra::{Point2};
+use nalgebra_glm::RealNumber;
 use num_traits::{Float, FromPrimitive};
 
 use crate::graphics::drawable::DrawOptions;
 use crate::graphics::drawable_ops::OpSet;
 
-pub trait PatternFiller<F: Float + Trig + FromPrimitive, P: BorrowMut<Vec<Vec<Point2D<F>>>>> {
+pub trait PatternFiller<F: RealNumber, P: BorrowMut<Vec<Vec<Point2<F>>>>> {
     fn fill_polygons(&self, polygon_list: P, o: &mut DrawOptions) -> OpSet<F>;
 }

--- a/roughfeel/src/graphics/geometry.rs
+++ b/roughfeel/src/graphics/geometry.rs
@@ -1,75 +1,84 @@
 // Copy from https://github.com/orhanbalci/rough-rs/blob/main/roughr/src/geometry.rs
-use euclid::default::Point2D;
-use euclid::{Angle, Translation2D, Trig, Vector2D};
+use nalgebra::{Point2, Vector2, Rotation2, Scalar};
+use nalgebra_glm::RealNumber;
+// use euclid::default::Point2;
+// use euclid::{Angle, Translation2D, Trig, Vector2D};
 use num_traits::{Float, FromPrimitive};
 
 use super::_c;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Line<F: Float + Trig> {
-    pub start_point: Point2D<F>,
-    pub end_point: Point2D<F>,
+pub struct Line<F: RealNumber> {
+    pub start_point: Point2<F>,
+    pub end_point: Point2<F>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct BezierQuadratic<F: Float + Trig> {
-    pub start: Point2D<F>,
-    pub cp: Point2D<F>,
-    pub end: Point2D<F>,
+pub struct BezierQuadratic<F: RealNumber> {
+    pub start: Point2<F>,
+    pub cp: Point2<F>,
+    pub end: Point2<F>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct BezierCubic<F: Float + Trig> {
-    pub start: Point2D<F>,
-    pub cp1: Point2D<F>,
-    pub cp2: Point2D<F>,
-    pub end: Point2D<F>,
+pub struct BezierCubic<F: RealNumber> {
+    pub start: Point2<F>,
+    pub cp1: Point2<F>,
+    pub cp2: Point2<F>,
+    pub end: Point2<F>,
 }
 
-impl<F: Float + Trig> Line<F> {
-    pub fn from(points: &[Point2D<F>]) -> Self {
+impl<F: RealNumber> Line<F> {
+    pub fn from(points: &[Point2<F>]) -> Self {
         Line {
             start_point: points[0],
             end_point: points[1],
         }
     }
 
-    pub fn as_points(&self) -> Vec<Point2D<F>> {
+    pub fn as_points(&self) -> Vec<Point2<F>> {
         return vec![self.start_point, self.end_point];
     }
 
     pub fn length(&self) -> F {
-        (self.end_point - self.start_point).length()
+        nalgebra::distance(&self.start_point, &self.end_point)
     }
 
     /// Rotate a line by `degrees` around a `center`. The center may not be the midpoint of the line.
-    pub fn rotate(&mut self, center: &Point2D<F>, degrees: F) {
+    pub fn rotate(&mut self, center: &Point2<F>, degrees: F) {
         let rotated_end_points = rotate_points(&[self.start_point, self.end_point], center, degrees);
         self.start_point = rotated_end_points[0];
         self.end_point = rotated_end_points[1];
     }
 }
 
-pub fn rotate_points<F: Float + Trig>(
-    points: &[Point2D<F>],
-    center: &Point2D<F>,
-    degrees: F,
-) -> Vec<Point2D<F>> {
-    let angle = Angle::radians(degrees.to_radians());
-    let translation = Translation2D::new(-center.x, -center.y);
-    let transformation = translation
-        .to_transform()
-        .then_rotate(angle)
-        .then_translate(Vector2D::new(center.x, center.y));
-    return points
-        .iter()
-        .map(|&p| transformation.transform_point(p))
-        .collect::<Vec<Point2D<F>>>();
+fn degree_to_radians<F: RealNumber>(degrees: F) -> F {
+    degrees / F::from_f64(180.0 * 3.141592653589793238).unwrap()
 }
 
-pub fn rotate_lines<F: Float + Trig>(
+pub fn rotate_points<F: RealNumber>(
+    points: &[Point2<F>],
+    center: &Point2<F>,
+    degrees: F,
+) -> Vec<Point2<F>> {
+    let angle = degree_to_radians(degrees);
+    let translation_to_center = Vector2::new(center.x, center.y);
+    let rot_mat = Rotation2::new(angle);
+    rot_mat * points[0];
+    // let translation = Translation2D::new(-center.x, -center.y);
+    // let transformation = translation
+    //     .to_transform()
+    //     .then_rotate(angle)
+    //     .then_translate(Vector2D::new(center.x, center.y));
+    return points
+        .iter()
+        .map(|&p| (rot_mat * (p - translation_to_center) + translation_to_center))
+        .collect::<Vec<Point2<F>>>();
+}
+
+pub fn rotate_lines<F: RealNumber>(
     lines: &[Line<F>],
-    center: &Point2D<F>,
+    center: &Point2<F>,
     degrees: F,
 ) -> Vec<Line<F>> {
     lines
@@ -83,7 +92,7 @@ pub fn rotate_lines<F: Float + Trig>(
 }
 
 /// Raises the order from a quadratic bezier to a cubic bezier curve.
-pub fn convert_bezier_quadratic_to_cubic<F: Float + FromPrimitive + Trig>(
+pub fn convert_bezier_quadratic_to_cubic<F: RealNumber>(
     bezier_quadratic: BezierQuadratic<F>,
 ) -> BezierCubic<F> {
     // This can be verified by substituting the following points in the cubic Bézier curves.
@@ -99,18 +108,18 @@ pub fn convert_bezier_quadratic_to_cubic<F: Float + FromPrimitive + Trig>(
 
     BezierCubic {
         start: bezier_quadratic.start,
-        cp1: Point2D::new(cubic_x1, cubic_y1),
-        cp2: Point2D::new(cubic_x2, cubic_y2),
+        cp1: Point2::new(cubic_x1, cubic_y1),
+        cp2: Point2::new(cubic_x2, cubic_y2),
         end: bezier_quadratic.end,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use euclid::default::Point2D;
+    use nalgebra::Point2;
     #[test]
     fn line_length() {
-        let l = super::Line::from(&[Point2D::new(1.0, 1.0), Point2D::new(2.0, 2.0)]);
+        let l = super::Line::from(&[Point2::new(1.0, 1.0), Point2::new(2.0, 2.0)]);
         assert_eq!(l.length(), f32::sqrt(2.0));
     }
 }

--- a/roughfeel/src/graphics/mod.rs
+++ b/roughfeel/src/graphics/mod.rs
@@ -1,3 +1,5 @@
+use nalgebra::{Vector};
+use nalgebra_glm::RealNumber;
 use num_traits::{Float, FromPrimitive};
 
 pub mod drawable;
@@ -10,10 +12,24 @@ pub mod points_on_path;
 pub mod render_context;
 pub mod renderer;
 
-pub fn _c<U: Float + FromPrimitive>(inp: f32) -> U {
-    U::from(inp).expect("can not parse from f32")
+use std::{f32, f64};
+
+pub fn _c<U: RealNumber>(inp: f32) -> U {
+    U::from_f32(inp).expect("can not parse from f32")
 }
 
-pub fn _cc<U: Float + FromPrimitive>(inp: f64) -> U {
-    U::from(inp).expect("can not parse from f64")
+pub fn _cc<U: RealNumber>(inp: f64) -> U {
+    U::from_f64(inp).expect("can not parse from f64")
+}
+
+pub fn _to_u64<U: RealNumber>(inp: U) -> u64 {
+    _to_f64(inp) as u64
+}
+
+pub fn _to_f64<U: RealNumber>(inp: U) -> f64 {
+    nalgebra::try_convert(inp).unwrap()
+}
+
+pub fn _to_f32<U: RealNumber>(inp: U) -> f32 {
+    nalgebra::try_convert(inp).unwrap() as f32
 }

--- a/roughfeel/src/graphics/points_on_path.rs
+++ b/roughfeel/src/graphics/points_on_path.rs
@@ -1,8 +1,10 @@
 use std::fmt::Display;
 use std::ops::MulAssign;
 
-use euclid::default::Point2D;
-use euclid::Trig;
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
+// use euclid::default::Point2;
+// use euclid::Trig;
 use num_traits::{Float, FromPrimitive};
 use points_on_curve::{points_on_bezier_curves, simplify};
 use svg_path_ops::{absolutize, normalize};
@@ -14,9 +16,9 @@ pub fn points_on_path<F>(
     path: String,
     tolerance: Option<F>,
     distance: Option<F>,
-) -> Vec<Vec<Point2D<F>>>
+) -> Vec<Vec<Point2<F>>>
 where
-    F: FromPrimitive + Trig + Float + MulAssign + Display,
+    F: RealNumber + Display,
 {
     let path_parser = PathParser::from(path.as_ref());
     let path_segments: Vec<PathSegment> = path_parser.flatten().collect();
@@ -24,13 +26,13 @@ where
     // normalized_segments
     //     .by_ref()
     //     .for_each(|a| print_line_segment(&a));
-    let mut sets: Vec<Vec<Point2D<F>>> = vec![];
-    let mut current_points: Vec<Point2D<F>> = vec![];
-    let mut start = Point2D::new(_c::<F>(0.0), _c::<F>(0.0));
-    let mut pending_curve: Vec<Point2D<F>> = vec![];
+    let mut sets: Vec<Vec<Point2<F>>> = vec![];
+    let mut current_points: Vec<Point2<F>> = vec![];
+    let mut start = Point2::new(_c::<F>(0.0), _c::<F>(0.0));
+    let mut pending_curve: Vec<Point2<F>> = vec![];
 
     let append_pending_curve =
-        |current_points: &mut Vec<Point2D<F>>, pending_curve: &mut Vec<Point2D<F>>| {
+        |current_points: &mut Vec<Point2<F>>, pending_curve: &mut Vec<Point2<F>>| {
             if pending_curve.len() >= 4 {
                 current_points.append(&mut points_on_bezier_curves(
                     &pending_curve[..],
@@ -42,7 +44,7 @@ where
         };
 
     let mut append_pending_points =
-        |current_points: &mut Vec<Point2D<F>>, pending_curve: &mut Vec<Point2D<F>>| {
+        |current_points: &mut Vec<Point2<F>>, pending_curve: &mut Vec<Point2<F>>| {
             {
                 append_pending_curve(current_points, pending_curve);
             }
@@ -56,12 +58,12 @@ where
         match segment {
             PathSegment::MoveTo { abs: true, x, y } => {
                 append_pending_points(&mut current_points, &mut pending_curve);
-                start = Point2D::new(_cc::<F>(x), _cc::<F>(y));
+                start = Point2::new(_cc::<F>(x), _cc::<F>(y));
                 current_points.push(start);
             }
             PathSegment::LineTo { abs: true, x, y } => {
                 append_pending_curve(&mut current_points, &mut pending_curve);
-                current_points.push(Point2D::new(_cc::<F>(x), _cc::<F>(y)));
+                current_points.push(Point2::new(_cc::<F>(x), _cc::<F>(y)));
             }
             PathSegment::CurveTo {
                 abs: true,
@@ -80,9 +82,9 @@ where
                     };
                     pending_curve.push(*last_point);
                 }
-                pending_curve.push(Point2D::new(_cc::<F>(x1), _cc::<F>(y1)));
-                pending_curve.push(Point2D::new(_cc::<F>(x2), _cc::<F>(y2)));
-                pending_curve.push(Point2D::new(_cc::<F>(x), _cc::<F>(y)));
+                pending_curve.push(Point2::new(_cc::<F>(x1), _cc::<F>(y1)));
+                pending_curve.push(Point2::new(_cc::<F>(x2), _cc::<F>(y2)));
+                pending_curve.push(Point2::new(_cc::<F>(x), _cc::<F>(y)));
             }
             PathSegment::ClosePath { abs: true } => {
                 append_pending_curve(&mut current_points, &mut pending_curve);

--- a/roughfeel/src/graphics/render_context.rs
+++ b/roughfeel/src/graphics/render_context.rs
@@ -3,7 +3,9 @@ use std::ops::MulAssign;
 
 use num_traits::{Float, FromPrimitive};
 
-use euclid::{default::Point2D, Trig};
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
+// use euclid::{default::Point2, Trig};
 
 use super::drawable_ops::OpSet;
 
@@ -21,7 +23,7 @@ impl RoughRenderContext {
     fn d<T, F, OutputDrawable: Drawable>(&self, name: T, op_sets: &[OpSet<F>], options: &Option<DrawOptions>) -> OutputDrawable
     where
         T: Into<String>,
-        F: Float + Trig + FromPrimitive,
+        F: Float + FromPrimitive,
     {
         OutputDrawable::draw {
             shape: name.into(),
@@ -34,7 +36,7 @@ impl RoughRenderContext {
 
     pub fn line<F, OutputDrawable: Drawable>(&self, x1: F, y1: F, x2: F, y2: F, options: &Option<DrawOptions>) -> OutputDrawable
     where
-        F: Float + Trig + FromPrimitive,
+        F: Float + FromPrimitive,
     {
         self.d(
             "line",
@@ -54,7 +56,7 @@ impl RoughRenderContext {
 */
 
 pub trait RoughlyCanvas<
-    F: Trig + Float + FromPrimitive + MulAssign + Display,
+    F: RealNumber + FromPrimitive + MulAssign + Display,
     D: Drawable<OpSet<F>>,
 >
 {
@@ -66,23 +68,23 @@ pub trait RoughlyCanvas<
 
     fn draw_circle(&self, x: F, y: F, diameter: F, options: DrawOptions);
 
-    fn draw_linear_path(&self, points: &[Point2D<F>], close: bool, options: DrawOptions);
+    fn draw_linear_path(&self, points: &[Point2<F>], close: bool, options: DrawOptions);
 
-    fn draw_polygon(&self, points: &[Point2D<F>]);
+    fn draw_polygon(&self, points: &[Point2<F>]);
 
     fn draw_arc(&self, x: F, y: F, width: F, height: F, start: F, stop: F, closed: bool);
 
-    fn draw_bezier_quadratic(&self, start: Point2D<F>, cp: Point2D<F>, end: Point2D<F>);
+    fn draw_bezier_quadratic(&self, start: Point2<F>, cp: Point2<F>, end: Point2<F>);
 
     fn draw_bezier_cubic(
         &self,
-        start: Point2D<F>,
-        cp1: Point2D<F>,
-        cp2: Point2D<F>,
-        end: Point2D<F>,
+        start: Point2<F>,
+        cp1: Point2<F>,
+        cp2: Point2<F>,
+        end: Point2<F>,
     );
 
-    fn draw_curve(&self, points: &[Point2D<F>]);
+    fn draw_curve(&self, points: &[Point2<F>]);
 
     fn draw_path(&self, svg_path: String);
 }

--- a/roughfeel/src/renderer_engine/kurbo_drawable_maker.rs
+++ b/roughfeel/src/renderer_engine/kurbo_drawable_maker.rs
@@ -2,7 +2,8 @@ use std::{fmt::Display, ops::MulAssign};
 
 use num_traits::{Float, FromPrimitive};
 
-use euclid::{default::Point2D, Trig};
+use nalgebra::{Point2, Scalar};
+use nalgebra_glm::RealNumber;
 
 use crate::graphics::{
     drawable::{DrawOptions, Drawable},
@@ -16,7 +17,7 @@ use std::marker::PhantomData;
 
 #[derive(Default)]
 pub struct KurboDrawableMaker<
-    F: Trig + Float + FromPrimitive + MulAssign + Display,
+    F: RealNumber + Display,
     OutputDrawable: Drawable<KurboOpSet<F>>,
 > {
     gen: Generator<OpSet<F>>,
@@ -24,7 +25,7 @@ pub struct KurboDrawableMaker<
     phantom_data_output_drawable: PhantomData<OutputDrawable>,
 }
 
-impl<F: Float + Trig + FromPrimitive + MulAssign + Display,
+impl<F: RealNumber + FromPrimitive + MulAssign + Display,
         OutputDrawable: Drawable<KurboOpSet<F>>,
     > KurboDrawableMaker<F, OutputDrawable>
 {
@@ -38,7 +39,7 @@ impl<F: Float + Trig + FromPrimitive + MulAssign + Display,
 }
 
 impl<
-        F: Float + Trig + FromPrimitive + MulAssign + Display,
+        F: RealNumber + MulAssign + Display,
         OutputDrawable: Drawable<KurboOpSet<F>>,
     > RoughlyDrawableMaker<F, KurboOpSet<F>, KurboDrawable<F>>
     for KurboDrawableMaker<F, OutputDrawable>
@@ -79,7 +80,7 @@ impl<
 
     fn linear_path(
         &self,
-        points: &[Point2D<F>],
+        points: &[Point2<F>],
         close: bool,
         options: &Option<DrawOptions>,
     ) -> KurboDrawable<F> {
@@ -87,7 +88,7 @@ impl<
         drawable.to_kurbo_drawable()
     }
 
-    fn polygon(&self, points: &[Point2D<F>], options: &Option<DrawOptions>) -> KurboDrawable<F> {
+    fn polygon(&self, points: &[Point2<F>], options: &Option<DrawOptions>) -> KurboDrawable<F> {
         let drawable = self.gen.polygon(points, options);
         drawable.to_kurbo_drawable()
     }
@@ -111,9 +112,9 @@ impl<
 
     fn bezier_quadratic(
         &self,
-        start: Point2D<F>,
-        cp: Point2D<F>,
-        end: Point2D<F>,
+        start: Point2<F>,
+        cp: Point2<F>,
+        end: Point2<F>,
         options: &Option<DrawOptions>,
     ) -> KurboDrawable<F> {
         let drawable = self.gen.bezier_quadratic(start, cp, end, options);
@@ -122,17 +123,17 @@ impl<
 
     fn bezier_cubic(
         &self,
-        start: Point2D<F>,
-        cp1: Point2D<F>,
-        cp2: Point2D<F>,
-        end: Point2D<F>,
+        start: Point2<F>,
+        cp1: Point2<F>,
+        cp2: Point2<F>,
+        end: Point2<F>,
         options: &Option<DrawOptions>,
     ) -> KurboDrawable<F> {
         let drawable = self.gen.bezier_cubic(start, cp1, cp2, end, options);
         drawable.to_kurbo_drawable()
     }
 
-    fn curve(&self, points: &[Point2D<F>], options: &Option<DrawOptions>) -> KurboDrawable<F> {
+    fn curve(&self, points: &[Point2<F>], options: &Option<DrawOptions>) -> KurboDrawable<F> {
         let drawable = self.gen.curve(points, options);
         drawable.to_kurbo_drawable()
     }


### PR DESCRIPTION
# Motivation
`euclid` is a lightweight library but it is replaced with `nalgebra` due to the following reasons:
1. nalgebra is faster than euclid according to https://github.com/bitshifter/mathbench-rs
2. Linear algebra functions are not well supported in euclid. After using nalgebra, some of the code could be simplify and easier to maintain.